### PR TITLE
Fixes for containerized builds

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -5,6 +5,7 @@ component "facter" do |pkg, settings, platform|
 
   flags = " --bindir=#{settings[:bindir]} \
             --sitelibdir=#{settings[:ruby_vendordir]} \
+            --man \
             --mandir=#{settings[:mandir]} \
             --ruby=#{File.join(settings[:bindir], 'ruby')} "
 
@@ -19,10 +20,12 @@ component "facter" do |pkg, settings, platform|
   end
 
   pkg.install do
-    ["#{settings[:host_ruby]} install.rb \
-    --no-batch-files \
-    --no-configs \
-    #{flags}"]
+    [
+      "#{settings[:host_ruby]} install.rb \
+      --no-batch-files \
+      --no-configs \
+      #{flags}"
+    ]
   end
 
   pkg.install_file "facter.gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}-#{pkg.get_version_forced}.gemspec"

--- a/configs/platforms/debian-10-amd64.rb
+++ b/configs/platforms/debian-10-amd64.rb
@@ -1,11 +1,3 @@
 platform "debian-10-amd64" do |plat|
-  plat.servicedir "/lib/systemd/system"
-  plat.defaultdir "/etc/default"
-  plat.servicetype "systemd"
-  plat.codename "buster"
-
-  packages = ['build-essential', 'devscripts', 'rsync', 'fakeroot', 'debhelper']
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
-  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vmpooler_template "debian-10-x86_64"
+  plat.inherit_from_default
 end

--- a/configs/platforms/el-7-x86_64.rb
+++ b/configs/platforms/el-7-x86_64.rb
@@ -1,10 +1,3 @@
 platform "el-7-x86_64" do |plat|
-  plat.servicedir "/usr/lib/systemd/system"
-  plat.defaultdir "/etc/sysconfig"
-  plat.servicetype "systemd"
-
-  packages = ['make', 'rsync', 'rpm-build']
-  plat.provision_with "yum install --assumeyes #{packages.join(' ')}"
-  plat.install_build_dependencies_with "yum install --assumeyes"
-  plat.vmpooler_template "centos-7-x86_64"
+  plat.inherit_from_default
 end

--- a/configs/platforms/el-8-aarch64.rb
+++ b/configs/platforms/el-8-aarch64.rb
@@ -1,11 +1,3 @@
 platform "el-8-aarch64" do |plat|
-  plat.servicedir "/usr/lib/systemd/system"
-  plat.defaultdir "/etc/sysconfig"
-  plat.servicetype "systemd"
-
-  packages = %w(gcc-c++ rsync make rpm-libs rpm-build)
-
-  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
-  plat.install_build_dependencies_with "dnf install -y --allowerasing "
-  plat.vmpooler_template "redhat-8-arm64"
+  plat.inherit_from_default
 end

--- a/configs/platforms/el-8-ppc64le.rb
+++ b/configs/platforms/el-8-ppc64le.rb
@@ -1,14 +1,3 @@
 platform "el-8-ppc64le" do |plat|
-  plat.servicedir "/usr/lib/systemd/system"
-  plat.defaultdir "/etc/sysconfig"
-  plat.servicetype "systemd"
-
-  # Workaround for an issue with RedHat subscription metadata, see ITSYS-2543
-  plat.provision_with('subscription-manager repos --disable rhel-8-for-ppc64le-baseos-rpms && subscription-manager repos --enable rhel-8-for-ppc64le-baseos-rpms')
-
-  packages = %w(gcc gcc-c++ autoconf automake createrepo rsync cmake make rpm-libs rpm-build libarchive)
-
-  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
-  plat.install_build_dependencies_with "dnf install -y --allowerasing "
-  plat.vmpooler_template "redhat-8-power8"
+  plat.inherit_from_default
 end

--- a/configs/platforms/el-8-x86_64.rb
+++ b/configs/platforms/el-8-x86_64.rb
@@ -1,10 +1,3 @@
 platform "el-8-x86_64" do |plat|
-  plat.servicedir "/usr/lib/systemd/system"
-  plat.defaultdir "/etc/sysconfig"
-  plat.servicetype "systemd"
-
-  packages = ['make', 'rsync', 'rpm-build']
-  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
-  plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.inherit_from_default
 end

--- a/configs/platforms/el-9-aarch64.rb
+++ b/configs/platforms/el-9-aarch64.rb
@@ -1,11 +1,3 @@
 platform "el-9-aarch64" do |plat|
-  plat.servicedir "/usr/lib/systemd/system"
-  plat.defaultdir "/etc/sysconfig"
-  plat.servicetype "systemd"
-
-  packages = %w(gcc-c++ rsync make rpm-libs rpm-build)
-
-  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
-  plat.install_build_dependencies_with "dnf install -y --allowerasing "
-  plat.vmpooler_template "redhat-9-arm64"
+  plat.inherit_from_default
 end

--- a/configs/platforms/el-9-ppc64le.rb
+++ b/configs/platforms/el-9-ppc64le.rb
@@ -1,8 +1,3 @@
 platform 'el-9-ppc64le' do |plat|
   plat.inherit_from_default
-
-  packages = %w(gcc gcc-c++ autoconf automake createrepo rsync cmake make rpm-libs rpm-build libarchive)
-  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
-  plat.install_build_dependencies_with 'dnf install -y --allowerasing '
-  plat.vmpooler_template 'redhat-9-power9'
 end

--- a/configs/platforms/fedora-36-x86_64.rb
+++ b/configs/platforms/fedora-36-x86_64.rb
@@ -1,6 +1,3 @@
 platform 'fedora-36-x86_64' do |plat|
   plat.inherit_from_default
-
-  packages = %w[binutils]
-  plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
 end

--- a/configs/platforms/sles-12-x86_64.rb
+++ b/configs/platforms/sles-12-x86_64.rb
@@ -1,10 +1,3 @@
 platform "sles-12-x86_64" do |plat|
-  plat.servicedir "/usr/lib/systemd/system"
-  plat.defaultdir "/etc/sysconfig"
-  plat.servicetype "systemd"
-
-  packages = ['make', 'rsync', 'rpm-build']
-  plat.provision_with "zypper -n --no-gpg-checks install -y #{packages.join(' ')}"
-  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
-  plat.vmpooler_template "sles-12-x86_64"
+  plat.inherit_from_default
 end

--- a/configs/platforms/sles-15-x86_64.rb
+++ b/configs/platforms/sles-15-x86_64.rb
@@ -1,10 +1,3 @@
 platform "sles-15-x86_64" do |plat|
-  plat.servicedir "/usr/lib/systemd/system"
-  plat.defaultdir "/etc/sysconfig"
-  plat.servicetype "systemd"
-
-  packages = ['make', 'rsync', 'rpm-build']
-  plat.provision_with "zypper -n --no-gpg-checks install -y #{packages.join(' ')}"
-  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
-  plat.vmpooler_template "sles-15-x86_64"
+  plat.inherit_from_default
 end

--- a/configs/platforms/ubuntu-18.04-amd64.rb
+++ b/configs/platforms/ubuntu-18.04-amd64.rb
@@ -1,11 +1,3 @@
 platform "ubuntu-18.04-amd64" do |plat|
-  plat.servicedir "/lib/systemd/system"
-  plat.defaultdir "/etc/default"
-  plat.servicetype "systemd"
-  plat.codename "bionic"
-
-  packages = ['build-essential', 'devscripts', 'rsync', 'fakeroot', 'debhelper']
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
-  plat.install_build_dependencies_with "apt-get install -qy --no-install-recommends "
-  plat.vmpooler_template "ubuntu-1804-x86_64"
+  plat.inherit_from_default
 end

--- a/configs/platforms/ubuntu-20.04-aarch64.rb
+++ b/configs/platforms/ubuntu-20.04-aarch64.rb
@@ -1,10 +1,3 @@
 platform "ubuntu-20.04-aarch64" do |plat|
-  plat.servicedir "/lib/systemd/system"
-  plat.defaultdir "/etc/default"
-  plat.servicetype "systemd"
-  plat.codename "focal"
-
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake"
-  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vmpooler_template "ubuntu-2004-arm64"
+  plat.inherit_from_default
 end

--- a/configs/platforms/ubuntu-20.04-amd64.rb
+++ b/configs/platforms/ubuntu-20.04-amd64.rb
@@ -1,11 +1,3 @@
 platform "ubuntu-20.04-amd64" do |plat|
-  plat.servicedir "/lib/systemd/system"
-  plat.defaultdir "/etc/default"
-  plat.servicetype "systemd"
-  plat.codename "focal"
-
-  packages = ['build-essential', 'devscripts', 'rsync', 'fakeroot', 'debhelper']
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
-  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vmpooler_template "ubuntu-2004-x86_64"
+  plat.inherit_from_default
 end


### PR DESCRIPTION
You'll need to point to your own pxp-agent and puppet-runtime build. For use with https://github.com/overlookinfra/vanagon/pull/1, https://github.com/overlookinfra/puppet-runtime/pull/1, and https://github.com/overlookinfra/pxp-agent-vanagon/pull/1.